### PR TITLE
Anility specific pipedrive actions

### DIFF
--- a/components/pipedrive/anility-actions/add-deal/add-deal-if-missing.mjs
+++ b/components/pipedrive/anility-actions/add-deal/add-deal-if-missing.mjs
@@ -1,0 +1,189 @@
+import pipedriveApp from "../../pipedrive.app.mjs";
+
+export default {
+  key: "anility-pipedrive-add-deal",
+  name: "Add Deal (Anility)",
+  description: "Adds a new deal if missing. See the Pipedrive API docs for Deals [here](https://developers.pipedrive.com/docs/api/v1/Deals#addDeal)",
+  version: "0.0.3",
+  type: "action",
+  props: {
+    pipedriveApp,
+    title: {
+      propDefinition: [
+        pipedriveApp,
+        "dealTitle",
+      ],
+    },
+    value: {
+      propDefinition: [
+        pipedriveApp,
+        "dealValue",
+      ],
+    },
+    currency: {
+      propDefinition: [
+        pipedriveApp,
+        "dealCurrency",
+      ],
+    },
+    userId: {
+      propDefinition: [
+        pipedriveApp,
+        "userId",
+      ],
+    },
+    personId: {
+      propDefinition: [
+        pipedriveApp,
+        "personId",
+      ],
+    },
+    organizationId: {
+      propDefinition: [
+        pipedriveApp,
+        "organizationId",
+      ],
+    },
+    stageId: {
+      propDefinition: [
+        pipedriveApp,
+        "stageId",
+      ],
+    },
+    status: {
+      propDefinition: [
+        pipedriveApp,
+        "status",
+      ],
+    },
+    probability: {
+      propDefinition: [
+        pipedriveApp,
+        "probability",
+      ],
+    },
+    lostReason: {
+      propDefinition: [
+        pipedriveApp,
+        "lostReason",
+      ],
+    },
+    visibleTo: {
+      propDefinition: [
+        pipedriveApp,
+        "visibleTo",
+      ],
+    },
+    addTime: {
+      propDefinition: [
+        pipedriveApp,
+        "addTime",
+      ],
+    },
+    pipelineId: {
+      propDefinition: [
+        pipedriveApp,
+        "pipelineId",
+      ],
+    },
+    anilityIdFieldKey: {
+      type: "string",
+      label: "AnilityId field key",
+      description: "Anility Id custom field in Pipedrive",
+    },
+    anilityIdFieldValue: {
+      type: "string",
+      label: "AnilityId field value",
+      description: "Anility Id custom field value in Pipedrive",
+    },
+    anilityCustomerIdFieldKey: {
+      type: "string",
+      label: "CustomerId field key",
+      description: "Pipedrive organization id for customer",
+    },
+    anilityCustomerIdFieldValue: {
+      type: "string",
+      label: "CustomerId field key",
+      description: "Pipedrive organization id  (value) for customer",
+    },
+    anilityOrderByIdFieldKey: {
+      type: "string",
+      label: "Order By Id field key",
+      description: "Pipedrive person id who ordered the assessment",
+    },
+    anilityOrderByIdFieldValue: {
+      type: "string",
+      label: "Order By Id field key",
+      description: "Pipedrive person id (value) who ordered the assessment",
+    },
+  },
+  async run({ $ }) {
+    const {
+      title,
+      value,
+      currency,
+      userId,
+      personId,
+      organizationId,
+      stageId,
+      status,
+      probability,
+      lostReason,
+      visibleTo,
+      addTime,
+      pipelineId,
+      anilityIdFieldKey,
+      anilityIdFieldValue,
+      anilityCustomerIdFieldKey,
+      anilityCustomerIdFieldValue,
+      anilityOrderByIdFieldKey,
+      anilityOrderByIdFieldValue,
+    } = this;
+
+    try {
+      const searchResp = await this.pipedriveApp.searchDeals({
+        term: anilityIdFieldValue,
+        fields: "custom_fields",
+        exact_match: true,
+        start: 0,
+        limit: 1,
+      });
+      if (searchResp.data.items.length === 0) {
+        var customFieldValue = {};
+        customFieldValue[anilityIdFieldKey] = anilityIdFieldValue;
+        customFieldValue[anilityCustomerIdFieldKey] = anilityCustomerIdFieldValue;
+        customFieldValue[anilityOrderByIdFieldKey] = anilityOrderByIdFieldValue;
+        const resp = await this.pipedriveApp.addDeal({
+          title,
+          value,
+          currency,
+          user_id: userId,
+          person_id: personId,
+          org_id: organizationId,
+          stage_id: stageId,
+          status,
+          probability,
+          lost_reason: lostReason,
+          visible_to: visibleTo,
+          add_time: addTime,
+          pipeline_id: pipelineId,
+          ...customFieldValue,
+        });
+
+        $.export("$summary", "Successfully added deal");
+
+        return resp;
+      }
+      else {
+        $.export("$summary", "Deal already exists");
+        return {
+          data: searchResp.data.items[0].item,
+        };
+      }
+
+    } catch (error) {
+      console.error(error.context?.body || error);
+      throw error.context?.body?.error || "Failed to add deal";
+    }
+  },
+};

--- a/components/pipedrive/anility-actions/add-deal/add-deal-if-missing.mjs
+++ b/components/pipedrive/anility-actions/add-deal/add-deal-if-missing.mjs
@@ -4,7 +4,7 @@ export default {
   key: "anility-pipedrive-add-deal",
   name: "Add Deal (Anility)",
   description: "Adds a new deal if missing. See the Pipedrive API docs for Deals [here](https://developers.pipedrive.com/docs/api/v1/Deals#addDeal)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   props: {
     pipedriveApp,
@@ -87,8 +87,10 @@ export default {
       ],
     },
     anilityIdFieldKey: {
-      type: "string",
-      label: "AnilityId field key",
+      propDefinition: [
+        pipedriveApp,
+        "dealCustomFieldKey",
+      ],
       description: "Anility Id custom field in Pipedrive",
     },
     anilityIdFieldValue: {
@@ -97,9 +99,11 @@ export default {
       description: "Anility Id custom field value in Pipedrive",
     },
     anilityCustomerIdFieldKey: {
-      type: "string",
-      label: "CustomerId field key",
-      description: "Pipedrive organization id for customer",
+      propDefinition: [
+        pipedriveApp,
+        "dealCustomFieldKey",
+      ],
+      description: "Customer Id custom field in Pipedrive",
     },
     anilityCustomerIdFieldValue: {
       type: "string",
@@ -107,9 +111,11 @@ export default {
       description: "Pipedrive organization id  (value) for customer",
     },
     anilityOrderByIdFieldKey: {
-      type: "string",
-      label: "Order By Id field key",
-      description: "Pipedrive person id who ordered the assessment",
+      propDefinition: [
+        pipedriveApp,
+        "dealCustomFieldKey",
+      ],
+      description: "Order By Id custom field in Pipedrive",
     },
     anilityOrderByIdFieldValue: {
       type: "string",

--- a/components/pipedrive/anility-actions/add-deal/add-deal-if-missing.mjs
+++ b/components/pipedrive/anility-actions/add-deal/add-deal-if-missing.mjs
@@ -4,7 +4,7 @@ export default {
   key: "anility-pipedrive-add-deal",
   name: "Add Deal (Anility)",
   description: "Adds a new deal if missing. See the Pipedrive API docs for Deals [here](https://developers.pipedrive.com/docs/api/v1/Deals#addDeal)",
-  version: "0.0.4",
+  version: "0.0.6",
   type: "action",
   props: {
     pipedriveApp,
@@ -122,6 +122,11 @@ export default {
       label: "Order By Id field key",
       description: "Pipedrive person id (value) who ordered the assessment",
     },
+    label: {
+      type: "string",
+      label: "label",
+      description: "Deal label",
+    },
   },
   async run({ $ }) {
     const {
@@ -144,7 +149,19 @@ export default {
       anilityCustomerIdFieldValue,
       anilityOrderByIdFieldKey,
       anilityOrderByIdFieldValue,
+      label,
     } = this;
+
+    const { data: stages } = await this.pipedriveApp.getDealFields();
+    var option = stages.find((stage) => stage.key === "label")
+      .options.find((option) => option.label.toLowerCase() === label.toLowerCase());
+
+    var labelValue = {};
+    if (option) {
+      labelValue["label"] = [
+        option.id,
+      ];
+    }
 
     try {
       const searchResp = await this.pipedriveApp.searchDeals({
@@ -174,6 +191,7 @@ export default {
           add_time: addTime,
           pipeline_id: pipelineId,
           ...customFieldValue,
+          ...labelValue,
         });
 
         $.export("$summary", "Successfully added deal");

--- a/components/pipedrive/anility-actions/add-organization/add-organization-if-missing.mjs
+++ b/components/pipedrive/anility-actions/add-organization/add-organization-if-missing.mjs
@@ -1,0 +1,92 @@
+import pipedriveApp from "../../pipedrive.app.mjs";
+
+export default {
+  key: "anility-pipedrive-add-organization-if-missing",
+  name: "Add Organization (Anility)",
+  description: "Adds a new organization. See the Pipedrive API docs for Organizations [here](https://developers.pipedrive.com/docs/api/v1/Organizations#addOrganization)",
+  version: "0.0.6",
+  type: "action",
+  props: {
+    pipedriveApp,
+    name: {
+      type: "string",
+      label: "Name",
+      description: "Organization name",
+    },
+    ownerId: {
+      label: "Owner ID",
+      description: "ID of the user who will be marked as the owner of this organization. When omitted, the authorized user ID will be used.",
+      propDefinition: [
+        pipedriveApp,
+        "userId",
+      ],
+    },
+    visibleTo: {
+      propDefinition: [
+        pipedriveApp,
+        "visibleTo",
+      ],
+      description: "Visibility of the organization. If omitted, visibility will be set to the default visibility setting of this item type for the authorized user.",
+    },
+    addTime: {
+      propDefinition: [
+        pipedriveApp,
+        "addTime",
+      ],
+      description: "Optional creation date & time of the organization in UTC. Requires admin user API token. Format: `YYYY-MM-DD HH:MM:SS`",
+    },
+    anilityIdFieldKey: {
+      type: "string",
+      label: "AnilityId field key",
+      description: "Anility Id custom field in Pipedrive",
+    },
+    anilityIdFieldValue: {
+      type: "string",
+      label: "AnilityId field value",
+      description: "Anility Id custom field value in Pipedrive",
+    },
+  },
+  async run({ $ }) {
+    const {
+      name,
+      ownerId,
+      visibleTo,
+      addTime,
+      anilityIdFieldKey,
+      anilityIdFieldValue,
+    } = this;
+
+    try {
+      const searchResp = await this.pipedriveApp.searchOrganization({
+        term: anilityIdFieldValue,
+        fields: "custom_fields",
+        exact_match: true,
+        start: 0,
+        limit: 1,
+      });
+      if (searchResp.data.items.length === 0) {
+        var customFieldValue = {};
+        customFieldValue[anilityIdFieldKey] = anilityIdFieldValue;
+        const resp = await this.pipedriveApp.addOrganization({
+          name,
+          owner_id: ownerId,
+          visible_to: visibleTo,
+          add_time: addTime,
+          ...customFieldValue,
+        });
+        $.export("$summary", "Successfully added organization");
+        return resp;
+      }
+      else {
+        $.export("$summary", "Organization already exists");
+        return {
+          data: searchResp.data.items[0].item,
+        };
+      }
+
+    } catch (error) {
+      console.error(error.context?.body || error);
+      throw error.context?.body?.error || "Failed to add organization";
+    }
+  },
+};

--- a/components/pipedrive/anility-actions/add-organization/add-organization-if-missing.mjs
+++ b/components/pipedrive/anility-actions/add-organization/add-organization-if-missing.mjs
@@ -4,7 +4,7 @@ export default {
   key: "anility-pipedrive-add-organization-if-missing",
   name: "Add Organization (Anility)",
   description: "Adds a new organization. See the Pipedrive API docs for Organizations [here](https://developers.pipedrive.com/docs/api/v1/Organizations#addOrganization)",
-  version: "0.0.8",
+  version: "0.0.9",
   type: "action",
   props: {
     pipedriveApp,
@@ -38,7 +38,7 @@ export default {
     anilityIdFieldKey: {
       propDefinition: [
         pipedriveApp,
-        "anilityIdFieldKey",
+        "orgCustomFieldKey",
       ],
       description: "Anility Id custom field in Pipedrive",
     },

--- a/components/pipedrive/anility-actions/add-organization/add-organization-if-missing.mjs
+++ b/components/pipedrive/anility-actions/add-organization/add-organization-if-missing.mjs
@@ -4,7 +4,7 @@ export default {
   key: "anility-pipedrive-add-organization-if-missing",
   name: "Add Organization (Anility)",
   description: "Adds a new organization. See the Pipedrive API docs for Organizations [here](https://developers.pipedrive.com/docs/api/v1/Organizations#addOrganization)",
-  version: "0.0.6",
+  version: "0.0.8",
   type: "action",
   props: {
     pipedriveApp,
@@ -36,8 +36,10 @@ export default {
       description: "Optional creation date & time of the organization in UTC. Requires admin user API token. Format: `YYYY-MM-DD HH:MM:SS`",
     },
     anilityIdFieldKey: {
-      type: "string",
-      label: "AnilityId field key",
+      propDefinition: [
+        pipedriveApp,
+        "anilityIdFieldKey",
+      ],
       description: "Anility Id custom field in Pipedrive",
     },
     anilityIdFieldValue: {

--- a/components/pipedrive/anility-actions/add-organization/add-organization-if-missing.mjs
+++ b/components/pipedrive/anility-actions/add-organization/add-organization-if-missing.mjs
@@ -4,7 +4,7 @@ export default {
   key: "anility-pipedrive-add-organization-if-missing",
   name: "Add Organization (Anility)",
   description: "Adds a new organization. See the Pipedrive API docs for Organizations [here](https://developers.pipedrive.com/docs/api/v1/Organizations#addOrganization)",
-  version: "0.0.9",
+  version: "0.0.10",
   type: "action",
   props: {
     pipedriveApp,
@@ -47,6 +47,11 @@ export default {
       label: "AnilityId field value",
       description: "Anility Id custom field value in Pipedrive",
     },
+    label: {
+      type: "string",
+      label: "label",
+      description: "Organization label",
+    },
   },
   async run({ $ }) {
     const {
@@ -56,9 +61,19 @@ export default {
       addTime,
       anilityIdFieldKey,
       anilityIdFieldValue,
+      label,
     } = this;
 
     try {
+      const { data: stages } = await this.pipedriveApp.getOrganizationFields();
+      var option = stages.find((stage) => stage.key === "label")
+        .options.find((option) => option.label === label);
+
+      var labelValue = {};
+      if (option) {
+        labelValue["label"] = option.id;
+      }
+
       const searchResp = await this.pipedriveApp.searchOrganization({
         term: anilityIdFieldValue,
         fields: "custom_fields",
@@ -75,6 +90,7 @@ export default {
           visible_to: visibleTo,
           add_time: addTime,
           ...customFieldValue,
+          ...labelValue,
         });
         $.export("$summary", "Successfully added organization");
         return resp;

--- a/components/pipedrive/anility-actions/add-organization/add-organization.mjs
+++ b/components/pipedrive/anility-actions/add-organization/add-organization.mjs
@@ -1,0 +1,72 @@
+import pipedriveApp from "../../pipedrive.app.mjs";
+
+export default {
+  key: "anility-pipedrive-add-organization",
+  name: "Add Organization (Anility)",
+  description: "Adds a new organization. See the Pipedrive API docs for Organizations [here](https://developers.pipedrive.com/docs/api/v1/Organizations#addOrganization)",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    pipedriveApp,
+    name: {
+      type: "string",
+      label: "Name",
+      description: "Organization name",
+    },
+    ownerId: {
+      label: "Owner ID",
+      description: "ID of the user who will be marked as the owner of this organization. When omitted, the authorized user ID will be used.",
+      propDefinition: [
+        pipedriveApp,
+        "userId",
+      ],
+    },
+    visibleTo: {
+      propDefinition: [
+        pipedriveApp,
+        "visibleTo",
+      ],
+      description: "Visibility of the organization. If omitted, visibility will be set to the default visibility setting of this item type for the authorized user.",
+    },
+    addTime: {
+      propDefinition: [
+        pipedriveApp,
+        "addTime",
+      ],
+      description: "Optional creation date & time of the organization in UTC. Requires admin user API token. Format: `YYYY-MM-DD HH:MM:SS`",
+    },
+    customFieldValue: {
+      type: "string",
+      label: "Custom field value",
+      description: "Optional custom field value. The format is JSON like value that can be parsed in javascript",
+    },
+  },
+  async run({ $ }) {
+    const {
+      name,
+      ownerId,
+      visibleTo,
+      addTime,
+      customFieldValue,
+    } = this;
+
+    try {
+      const fieldValues = JSON.parse(customFieldValue);
+      const resp =
+        await this.pipedriveApp.addOrganization({
+          name,
+          owner_id: ownerId,
+          visible_to: visibleTo,
+          add_time: addTime,
+          ...fieldValues,
+        });
+
+      $.export("$summary", "Successfully added organization");
+
+      return resp;
+    } catch (error) {
+      console.error(error.context?.body || error);
+      throw error.context?.body?.error || "Failed to add organization";
+    }
+  },
+};

--- a/components/pipedrive/anility-actions/add-person/add-person-if-missing.mjs
+++ b/components/pipedrive/anility-actions/add-person/add-person-if-missing.mjs
@@ -1,0 +1,123 @@
+import pipedriveApp from "../../pipedrive.app.mjs";
+
+export default {
+  key: "anility-pipedrive-add-person",
+  name: "Add Person (Anility)",
+  description: "Adds a new person if missing. See the Pipedrive API docs for People [here](https://developers.pipedrive.com/docs/api/v1/Persons#addPerson)",
+  version: "0.0.2",
+  type: "action",
+  props: {
+    pipedriveApp,
+    name: {
+      type: "string",
+      label: "Name",
+      description: "Person name",
+    },
+    ownerId: {
+      label: "Owner ID",
+      description: "ID of the user who will be marked as the owner of this person. When omitted, the authorized user ID will be used.",
+      propDefinition: [
+        pipedriveApp,
+        "userId",
+      ],
+    },
+    organizationId: {
+      propDefinition: [
+        pipedriveApp,
+        "organizationId",
+      ],
+      description: "ID of the organization this person will belong to.",
+    },
+    email: {
+      type: "any",
+      label: "Email",
+      description: "Email addresses (one or more) associated with the person, presented in the same manner as received by GET request of a person.",
+      optional: true,
+    },
+    phone: {
+      type: "any",
+      label: "Phone",
+      description: "Phone numbers (one or more) associated with the person, presented in the same manner as received by GET request of a person.",
+      optional: true,
+    },
+    visibleTo: {
+      propDefinition: [
+        pipedriveApp,
+        "visibleTo",
+      ],
+      description: "Visibility of the person. If omitted, visibility will be set to the default visibility setting of this item type for the authorized user.",
+    },
+    addTime: {
+      propDefinition: [
+        pipedriveApp,
+        "addTime",
+      ],
+      description: "Optional creation date & time of the person in UTC. Requires admin user API token. Format: `YYYY-MM-DD HH:MM:SS`",
+    },
+    anilityIdFieldKey: {
+      type: "string",
+      label: "AnilityId field key",
+      description: "Anility Id custom field in Pipedrive",
+    },
+    anilityIdFieldValue: {
+      type: "string",
+      label: "AnilityId field value",
+      description: "Anility Id custom field value in Pipedrive",
+    },
+  },
+  async run({ $ }) {
+    const {
+      name,
+      ownerId,
+      organizationId,
+      email,
+      phone,
+      visibleTo,
+      addTime,
+      anilityIdFieldKey,
+      anilityIdFieldValue,
+    } = this;
+
+    try {
+
+      const searchResp = await this.pipedriveApp.searchPersons({
+        term: anilityIdFieldValue,
+        fields: "custom_fields",
+        exact_match: true,
+        org_id: organizationId,
+        start: 0,
+        limit: 1,
+      });
+
+      if (searchResp.data.items.length === 0) {
+        var customFieldValue = {};
+        customFieldValue[anilityIdFieldKey] = anilityIdFieldValue;
+        const resp =
+          await this.pipedriveApp.addPerson({
+            name,
+            owner_id: ownerId,
+            org_id: organizationId,
+            email,
+            phone,
+            visible_to: visibleTo,
+            add_time: addTime,
+            ...customFieldValue,
+          });
+
+        $.export("$summary", "Successfully added person");
+
+        return resp;
+      }
+      else {
+        $.export("$summary", "Person already exists");
+        return {
+          data: searchResp.data.items[0].item,
+        };
+      }
+
+    } catch (error) {
+      console.error(error.context?.body || error);
+      throw error.context?.body?.error || "Failed to add person";
+    }
+  },
+};

--- a/components/pipedrive/anility-actions/add-person/add-person-if-missing.mjs
+++ b/components/pipedrive/anility-actions/add-person/add-person-if-missing.mjs
@@ -4,7 +4,7 @@ export default {
   key: "anility-pipedrive-add-person",
   name: "Add Person (Anility)",
   description: "Adds a new person if missing. See the Pipedrive API docs for People [here](https://developers.pipedrive.com/docs/api/v1/Persons#addPerson)",
-  version: "0.0.2",
+  version: "0.0.3",
   type: "action",
   props: {
     pipedriveApp,
@@ -55,8 +55,10 @@ export default {
       description: "Optional creation date & time of the person in UTC. Requires admin user API token. Format: `YYYY-MM-DD HH:MM:SS`",
     },
     anilityIdFieldKey: {
-      type: "string",
-      label: "AnilityId field key",
+      propDefinition: [
+        pipedriveApp,
+        "personCustomFieldKey",
+      ],
       description: "Anility Id custom field in Pipedrive",
     },
     anilityIdFieldValue: {

--- a/components/pipedrive/anility-actions/add-person/add-person-if-missing.mjs
+++ b/components/pipedrive/anility-actions/add-person/add-person-if-missing.mjs
@@ -4,7 +4,7 @@ export default {
   key: "anility-pipedrive-add-person",
   name: "Add Person (Anility)",
   description: "Adds a new person if missing. See the Pipedrive API docs for People [here](https://developers.pipedrive.com/docs/api/v1/Persons#addPerson)",
-  version: "0.0.3",
+  version: "0.0.4",
   type: "action",
   props: {
     pipedriveApp,
@@ -66,6 +66,11 @@ export default {
       label: "AnilityId field value",
       description: "Anility Id custom field value in Pipedrive",
     },
+    label: {
+      type: "string",
+      label: "label",
+      description: "Person label",
+    },
   },
   async run({ $ }) {
     const {
@@ -78,9 +83,19 @@ export default {
       addTime,
       anilityIdFieldKey,
       anilityIdFieldValue,
+      label,
     } = this;
 
     try {
+
+      const { data: stages } = await this.pipedriveApp.getPersonFields();
+      var option = stages.find((stage) => stage.key === "label")
+        .options.find((option) => option.label.toLowerCase() === label.toLowerCase());
+
+      var labelValue = {};
+      if (option) {
+        labelValue["label"] = option.id;
+      }
 
       const searchResp = await this.pipedriveApp.searchPersons({
         term: anilityIdFieldValue,
@@ -104,6 +119,7 @@ export default {
             visible_to: visibleTo,
             add_time: addTime,
             ...customFieldValue,
+            ...labelValue,
           });
 
         $.export("$summary", "Successfully added person");

--- a/components/pipedrive/anility-actions/search-deals/search-deals.mjs
+++ b/components/pipedrive/anility-actions/search-deals/search-deals.mjs
@@ -1,0 +1,71 @@
+import constants from "../../common/constants.mjs";
+import pipedriveApp from "../../pipedrive.app.mjs";
+
+export default {
+  key: "anility-pipedrive-search-deals",
+  name: "Search Deals (Anility)",
+  description: "Searches all deals by custom field. This endpoint is a wrapper of `/v1/itemSearch` with a narrower OAuth scope. Found organizations can be filtered by Organization ID. See the Pipedrive API docs [here](https://developers.pipedrive.com/docs/api/v1/Deals#searchDeals)",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    pipedriveApp,
+    term: {
+      type: "string",
+      label: "Search term",
+      description: "The search term to look for. Minimum 2 characters (or 1 if using exact_match).",
+    },
+    fields: {
+      type: "string",
+      label: "Search fields",
+      description: "A comma-separated string array. The fields to perform the search from. Defaults to all of them. Only the following custom field types are searchable: address, custom_fields, notes, name",
+      optional: true,
+      options: constants.FIELD_OPTIONS,
+    },
+    exactMatch: {
+      type: "boolean",
+      label: "Exact match",
+      description: "When enabled, only full exact matches against the given term are returned. It is not case sensitive.",
+      optional: true,
+    },
+    start: {
+      propDefinition: [
+        pipedriveApp,
+        "start",
+      ],
+    },
+    limit: {
+      propDefinition: [
+        pipedriveApp,
+        "limit",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const {
+      term,
+      fields,
+      exactMatch,
+      start,
+      limit,
+    } = this;
+
+    try {
+      const resp =
+        await this.pipedriveApp.searchDeals({
+          term,
+          fields,
+          exact_match: exactMatch,
+          start,
+          limit,
+        });
+
+      $.export("$summary", `Successfully found ${resp.data?.items.length || 0} deals`);
+
+      return resp;
+
+    } catch (error) {
+      console.error(error.context?.body || error);
+      throw error.context?.body?.error || "Failed to search deals";
+    }
+  },
+};

--- a/components/pipedrive/anility-actions/search-organization/search-organization.mjs
+++ b/components/pipedrive/anility-actions/search-organization/search-organization.mjs
@@ -1,0 +1,71 @@
+import constants from "../../common/constants.mjs";
+import pipedriveApp from "../../pipedrive.app.mjs";
+
+export default {
+  key: "anility-pipedrive-search-organizations",
+  name: "Search organizations (Anility)",
+  description: "Searches all organizations by `address`, `email`, `phone`, `notes` and/or custom fields. This endpoint is a wrapper of `/v1/itemSearch` with a narrower OAuth scope. Found organizations can be filtered by Organization ID. See the Pipedrive API docs [here](https://developers.pipedrive.com/docs/api/v1/Organizations#searchOrganization)",
+  version: "0.0.1",
+  type: "action",
+  props: {
+    pipedriveApp,
+    term: {
+      type: "string",
+      label: "Search term",
+      description: "The search term to look for. Minimum 2 characters (or 1 if using exact_match).",
+    },
+    fields: {
+      type: "string",
+      label: "Search fields",
+      description: "A comma-separated string array. The fields to perform the search from. Defaults to all of them. Only the following custom field types are searchable: address, custom_fields, notes, name",
+      optional: true,
+      options: constants.FIELD_OPTIONS,
+    },
+    exactMatch: {
+      type: "boolean",
+      label: "Exact match",
+      description: "When enabled, only full exact matches against the given term are returned. It is not case sensitive.",
+      optional: true,
+    },
+    start: {
+      propDefinition: [
+        pipedriveApp,
+        "start",
+      ],
+    },
+    limit: {
+      propDefinition: [
+        pipedriveApp,
+        "limit",
+      ],
+    },
+  },
+  async run({ $ }) {
+    const {
+      term,
+      fields,
+      exactMatch,
+      start,
+      limit,
+    } = this;
+
+    try {
+      const resp =
+        await this.pipedriveApp.searchOrganization({
+          term,
+          fields,
+          exact_match: exactMatch,
+          start,
+          limit,
+        });
+
+      $.export("$summary", `Successfully found ${resp.data?.items.length || 0} organizations`);
+
+      return resp;
+
+    } catch (error) {
+      console.error(error.context?.body || error);
+      throw error.context?.body?.error || "Failed to search organizations";
+    }
+  },
+};

--- a/components/pipedrive/anility-actions/update-deal/update-deal.mjs
+++ b/components/pipedrive/anility-actions/update-deal/update-deal.mjs
@@ -1,0 +1,149 @@
+import pipedriveApp from "../../pipedrive.app.mjs";
+
+export default {
+  key: "anility-pipedrive-update-deal",
+  name: "Update Deal (Anility)",
+  description: "Updates the properties of a deal. With optional custom field. See the Pipedrive API docs for Deals [here](https://developers.pipedrive.com/docs/api/v1/Deals#updateDeal)",
+  version: "0.0.2",
+  type: "action",
+  props: {
+    pipedriveApp,
+    dealId: {
+      description: "ID of the deal",
+      optional: false,
+      propDefinition: [
+        pipedriveApp,
+        "dealId",
+      ],
+    },
+    title: {
+      propDefinition: [
+        pipedriveApp,
+        "dealTitle",
+      ],
+      optional: true,
+    },
+    value: {
+      propDefinition: [
+        pipedriveApp,
+        "dealValue",
+      ],
+    },
+    currency: {
+      propDefinition: [
+        pipedriveApp,
+        "dealCurrency",
+      ],
+    },
+    userId: {
+      propDefinition: [
+        pipedriveApp,
+        "userId",
+      ],
+    },
+    personId: {
+      propDefinition: [
+        pipedriveApp,
+        "personId",
+      ],
+    },
+    organizationId: {
+      propDefinition: [
+        pipedriveApp,
+        "organizationId",
+      ],
+    },
+    stageId: {
+      propDefinition: [
+        pipedriveApp,
+        "stageId",
+      ],
+    },
+    status: {
+      propDefinition: [
+        pipedriveApp,
+        "status",
+      ],
+    },
+    probability: {
+      propDefinition: [
+        pipedriveApp,
+        "probability",
+      ],
+    },
+    lostReason: {
+      propDefinition: [
+        pipedriveApp,
+        "lostReason",
+      ],
+    },
+    visibleTo: {
+      propDefinition: [
+        pipedriveApp,
+        "visibleTo",
+      ],
+    },
+    customFieldKey: {
+      propDefinition: [
+        pipedriveApp,
+        "dealCustomFieldKey",
+      ],
+      label: "Custom field key",
+      description: "Custom field in Pipedrive",
+    },
+    customFieldValue: {
+      type: "string",
+      label: "Custom field value",
+      description: "Custom field value",
+    },
+
+  },
+  async run({ $ }) {
+    const {
+      dealId,
+      title,
+      value,
+      currency,
+      userId,
+      personId,
+      organizationId,
+      stageId,
+      status,
+      probability,
+      lostReason,
+      visibleTo,
+      customFieldKey,
+      customFieldValue,
+    } = this;
+
+    try {
+      const customField = {};
+      customField[customFieldKey] = customFieldValue;
+
+      const resp =
+        await this.pipedriveApp.updateDeal({
+          dealId,
+          title,
+          value,
+          currency,
+          user_id: userId,
+          person_id: personId,
+          org_id: organizationId,
+          stage_id: stageId,
+          status,
+          probability,
+          lost_reason: lostReason,
+          visible_to: visibleTo,
+          ...customField,
+        });
+
+      $.export("$summary", "Successfully updated deal");
+
+      return resp;
+
+    } catch (error) {
+      console.error(error.context?.body || error);
+      throw error.context?.body?.error || "Failed to update deal";
+    }
+  },
+};

--- a/components/pipedrive/anility-sources/common/base.mjs
+++ b/components/pipedrive/anility-sources/common/base.mjs
@@ -1,0 +1,176 @@
+import app from "../../pipedrive.app.mjs";
+import constants from "../../common/constants.mjs";
+import utils from "../../common/utils.mjs";
+import { DEFAULT_POLLING_SOURCE_TIMER_INTERVAL } from "@pipedream/platform";
+
+export default {
+  props: {
+    app,
+    db: "$.service.db",
+    timer: {
+      type: "$.interface.timer",
+      label: "Polling schedule",
+      description: "How often to poll the Pipedrive API",
+      default: {
+        intervalSeconds: DEFAULT_POLLING_SOURCE_TIMER_INTERVAL,
+      },
+    },
+  },
+  hooks: {
+    async deploy() {
+      const fieldId = await this.fetchFieldId();
+      const args = await this.getFilterArgs({
+        fieldId,
+      });
+      const { data: { id: filterId } } = await this.app.addFilter(args);
+      this.setFilterId(filterId);
+    },
+    async deactivate() {
+      await this.app.deleteFilter(this.getFilterId());
+    },
+  },
+  methods: {
+    getFilterId() {
+      return this.db.get(constants.FILTER_ID);
+    },
+    setFilterId(value) {
+      this.db.set(constants.FILTER_ID, value);
+    },
+    getFieldId() {
+      return this.db.get(constants.FIELD_ID);
+    },
+    setFieldId(value) {
+      this.db.set(constants.FIELD_ID, value);
+    },
+    getLastExecDateTime() {
+      return this.db.get(constants.LAST_EXEC_DATE_TIME);
+    },
+    setLastExecDateTime(value) {
+      this.db.set(constants.LAST_EXEC_DATE_TIME, value);
+    },
+    getFieldKey() {
+      throw new Error("getFieldKey not implemented");
+    },
+    getEventObject() {
+      throw new Error("getEventObject not implemented");
+    },
+    getEventAction() {
+      throw new Error("getEventAction not implemented");
+    },
+    getResourceFn() {
+      throw new Error("getResourceFn not implemented");
+    },
+    getResourceFnArgs() {
+      throw new Error("getResourceFnArgs not implemented");
+    },
+    getTimestamp() {
+      throw new Error("getTimestamp not implemented");
+    },
+    getFilterArgs() {
+      throw new Error("getFilterArgs not implemented");
+    },
+    getFieldsFn() {
+      throw new Error("getFieldsFn not implemented");
+    },
+    getMetaId(resource) {
+      return resource.id;
+    },
+    getConditions({
+      fieldId, value, additionalConditions = [],
+    } = {}) {
+      return {
+        glue: "and",
+        conditions: [
+          {
+            glue: "or",
+            conditions: [],
+          },
+          {
+            glue: "or",
+            conditions: additionalConditions,
+          },
+          {
+            glue: "and",
+            conditions: [
+              {
+                object: this.getEventObject(),
+                field_id: fieldId,
+                operator: ">",
+                value,
+                extra_value: null,
+              },
+            ],
+          },
+        ],
+      };
+    },
+    async fetchFieldId() {
+      const fieldId = this.getFieldId();
+
+      if (fieldId) {
+        return fieldId;
+      }
+      const getFields = this.getFieldsFn();
+      const { data: fields } = await getFields();
+      const field = fields.find(({ key }) => key === this.getFieldKey());
+
+      this.setFieldId(field.id);
+
+      return field.id;
+    },
+    generateMeta(resource) {
+      return {
+        id: this.getMetaId(resource),
+        summary: `${this.getEventObject()} ${resource.id} was ${this.getEventAction()}`,
+        ts: this.getTimestamp(resource),
+      };
+    },
+    processEvent(resource) {
+      const meta = this.generateMeta(resource);
+      this.$emit(resource, meta);
+    },
+    async processStreamEvents(stream) {
+      const resources = await utils.streamIterator(stream);
+
+      console.log("Last exec date time:", this.getLastExecDateTime());
+
+      if (resources.length === 0) {
+        console.log("No new events detected. Skipping...");
+        return;
+      }
+
+      const [
+        lastResource,
+      ] = resources;
+
+      resources.reverse().forEach(this.processEvent);
+
+      if (lastResource) {
+        this.setLastExecDateTime(this.getTimestamp(lastResource));
+        const lastDateTimeStr = lastResource[this.getFieldKey()];
+
+        const fieldId = await this.fetchFieldId();
+
+        const lastDate = new Date(lastDateTimeStr);
+        lastDate.setDate(lastDate.getDate() - 1); // subtract 1 day
+        const args = this.getFilterArgs({
+          fieldId,
+          value: lastDate.toISOString().split("T")[0],
+        });
+        await this.app.updateFilter({
+          filterId: this.getFilterId(),
+          ...args,
+        });
+      }
+    },
+  },
+  async run() {
+    const stream =
+      await this.app.getResourcesStream({
+        resourceFn: this.getResourceFn(),
+        resourceFnArgs: this.getResourceFnArgs(),
+      });
+
+    await this.processStreamEvents(stream);
+  },
+};

--- a/components/pipedrive/anility-sources/updated-deal/updated-deal.mjs
+++ b/components/pipedrive/anility-sources/updated-deal/updated-deal.mjs
@@ -1,0 +1,77 @@
+import constants from "../../common/constants.mjs";
+import common from "../common/base.mjs";
+
+export default {
+  ...common,
+  key: "anility-pipedrive-updated-deal",
+  name: "Anility Updated Assessments",
+  description: "Emit new event when an assessment is updated.",
+  version: "0.0.6",
+  type: "source",
+  dedupe: "greatest",
+  methods: {
+    ...common.methods,
+    getFieldsFn() {
+      return this.app.getDealFields;
+    },
+    getResourceFn() {
+      return this.app.getDeals;
+    },
+    getResourceFnArgs() {
+      return {
+        filter_id: this.getFilterId(),
+        sort: `${this.getFieldKey()} DESC, id DESC`,
+      };
+    },
+    getFieldKey() {
+      return constants.FIELD.UPDATE_TIME;
+    },
+    getEventObject() {
+      return constants.EVENT_OBJECT.DEAL;
+    },
+    getEventAction() {
+      return constants.EVENT_ACTION.UPDATED;
+    },
+    getMetaId(resource) {
+      return this.getTimestamp(resource);
+    },
+    getTimestamp(resource) {
+      return Date.parse(resource.update_time);
+    },
+    getFilterArgs({
+      fieldId, value = "3_months_ago",
+    } = {}) {
+      return {
+        type: constants.FILTER_TYPE.DEALS,
+        name: "Pipedream: Deals updated later than specific value",
+        conditions: this.getConditions({
+          fieldId,
+          value,
+          additionalConditions: [
+            {
+              object: this.getEventObject(),
+              field_id: "8",
+              operator: "=",
+              value: "2",
+              extra_value: null,
+            },
+            {
+              object: this.getEventObject(),
+              field_id: "8",
+              operator: "=",
+              value: "3",
+              extra_value: null,
+            },
+            {
+              object: this.getEventObject(),
+              field_id: "8",
+              operator: "=",
+              value: "4",
+              extra_value: null,
+            },
+          ],
+        }),
+      };
+    },
+  },
+};

--- a/components/pipedrive/common/constants.mjs
+++ b/components/pipedrive/common/constants.mjs
@@ -3,6 +3,7 @@ const FILTER_ID = "filterId";
 const FIELD_ID = "fieldId";
 const DEFAULT_PAGE_LIMIT = 20; // max is 500 per page
 const DEFAULT_MAX_ITEMS = DEFAULT_PAGE_LIMIT * 4;
+const LAST_EXEC_DATE_TIME = "lastExecDataTime";
 
 const STATUS_OPTIONS = [
   "open",
@@ -195,6 +196,7 @@ export default {
   VISIBLE_TO_OPTIONS,
   INCLUDE_FIELDS_OPTIONS,
   LAST_RESOURCE_PROPERTY,
+  LAST_EXEC_DATE_TIME,
   FILTER_ID,
   FIELD_ID,
   EVENT_OBJECT,

--- a/components/pipedrive/pipedrive.app.mjs
+++ b/components/pipedrive/pipedrive.app.mjs
@@ -251,6 +251,21 @@ export default {
         };
       },
     },
+    anilityIdFieldKey: {
+      type: "string",
+      label: "Anility Id Field Key",
+      description: "Key of the Anility Id custom field in Pipedrive",
+      optional: true,
+      async options() {
+        const { data: stages } = await this.getOrganizationFields();
+        return stages.map(({
+          key, name,
+        }) => ({
+          label: name,
+          value: key,
+        }));
+      },
+    },
   },
   methods: {
     setupToken() {

--- a/components/pipedrive/pipedrive.app.mjs
+++ b/components/pipedrive/pipedrive.app.mjs
@@ -178,6 +178,21 @@ export default {
         }));
       },
     },
+    pipelineId: {
+      type: "integer",
+      label: "Pipeline ID",
+      description: "ID of the pipeline this deal will be placed in (note that you can't supply the ID of the pipeline as this will be assigned automatically based on `stage_id`). If omitted, the deal will be placed in the first stage of the default pipeline. Get the `stage_id` from [here](https://developers.pipedrive.com/docs/api/v1/#!/Stages/get_stages).",
+      optional: true,
+      async options() {
+        const { data: stages } = await this.getPipelines();
+        return stages.map(({
+          id, name,
+        }) => ({
+          label: name,
+          value: id,
+        }));
+      },
+    },
     status: {
       type: "string",
       label: "Status",
@@ -312,6 +327,16 @@ export default {
       ] = constants.API.PERSONS;
       return this.api(className).searchPersons(term, otherOpts);
     },
+    searchOrganization(opts = {}) {
+      const {
+        term,
+        ...otherOpts
+      } = opts;
+      const [
+        className,
+      ] = constants.API.ORGANIZATIONS;
+      return this.api(className).searchOrganization(term, otherOpts);
+    },
     addFilter(opts = {}) {
       const [
         className,
@@ -341,6 +366,16 @@ export default {
         className,
       ] = constants.API.DEALS;
       return this.api(className).getDeals(opts);
+    },
+    searchDeals(opts = {}) {
+      const {
+        term,
+        ...otherOpts
+      } = opts;
+      const [
+        className,
+      ] = constants.API.DEALS;
+      return this.api(className).searchDeals(term, otherOpts);
     },
     getPersons(opts = {}) {
       const [
@@ -378,6 +413,12 @@ export default {
       ] = constants.API.STAGES;
       return this.api(className).getStages(opts);
     },
+    getPipelines(opts) {
+      const [
+        className,
+      ] = constants.API.PIPELINES;
+      return this.api(className).getPipelines(opts);
+    },
     getDealFields(opts = {}) {
       const [
         className,
@@ -389,6 +430,12 @@ export default {
         className,
       ] = constants.API.PERSON_FIELDS;
       return this.api(className).getPersonFields(opts);
+    },
+    getOrganizationFields(opts = {}) {
+      const [
+        className,
+      ] = constants.API.ORGANIZATION_FIELDS;
+      return this.api(className).getOrganizationFields(opts);
     },
     async *getResourcesStream({
       resourceFn,

--- a/components/pipedrive/pipedrive.app.mjs
+++ b/components/pipedrive/pipedrive.app.mjs
@@ -251,13 +251,43 @@ export default {
         };
       },
     },
-    anilityIdFieldKey: {
+    orgCustomFieldKey: {
       type: "string",
-      label: "Anility Id Field Key",
-      description: "Key of the Anility Id custom field in Pipedrive",
+      label: "Custom Field Key",
+      description: "Key of the custom field for organization in Pipedrive",
       optional: true,
       async options() {
         const { data: stages } = await this.getOrganizationFields();
+        return stages.map(({
+          key, name,
+        }) => ({
+          label: name,
+          value: key,
+        }));
+      },
+    },
+    personCustomFieldKey: {
+      type: "string",
+      label: "Custom Field Key",
+      description: "Key of the custom field for person in Pipedrive",
+      optional: true,
+      async options() {
+        const { data: stages } = await this.getPersonFields();
+        return stages.map(({
+          key, name,
+        }) => ({
+          label: name,
+          value: key,
+        }));
+      },
+    },
+    dealCustomFieldKey: {
+      type: "string",
+      label: "Anility Id Field Key",
+      description: "Key of the custom field for deal in Pipedrive",
+      optional: true,
+      async options() {
+        const { data: stages } = await this.getDealFields();
         return stages.map(({
           key, name,
         }) => ({
@@ -398,6 +428,12 @@ export default {
       ] = constants.API.PERSONS;
       return this.api(className).getPersons(opts);
     },
+    getPersonFields(opts = {}) {
+      const [
+        className,
+      ] = constants.API.PERSON_FIELDS;
+      return this.api(className).getPersonFields(opts);
+    },
     async getLeads(opts) {
       const [
         className,
@@ -439,12 +475,6 @@ export default {
         className,
       ] = constants.API.DEAL_FIELDS;
       return this.api(className).getDealFields(opts);
-    },
-    getPersonFields(opts = {}) {
-      const [
-        className,
-      ] = constants.API.PERSON_FIELDS;
-      return this.api(className).getPersonFields(opts);
     },
     getOrganizationFields(opts = {}) {
       const [


### PR DESCRIPTION
**I'll walk you through this in the next couple of days**

Pipedream does not support conditions in the individual steps. It support filtering but that will cancel the workflow and does not continue. Luckily we can customize action. This is some additional steps which is namespaced with anility- so it does not conflict with the original pipedrive actions.

### How to install cli
[Installing the cli](https://pipedream.com/docs/cli/reference/#installing-the-cli)

### How to publish the new actions

Note: These actions already published into our accounts. Every time you want to update the existing action you need to make sure the version is increased. You can find the version as `version` property  in the `.mjs` files

To publish new version of action you can run the following command 

```
$ pd publish <filename>
```

Please see documentation [here](https://pipedream.com/docs/cli/reference/#pd-publish) 

